### PR TITLE
Upgrade to time 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ the response is fresh.
 [dependencies]
 conduit = "0.9.0-alpha.2"
 conduit-middleware = "0.9.0-alpha.2"
-time = "0.1.0"
+time = { version = "0.2", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 conduit-test = "0.9.0-alpha.2"


### PR DESCRIPTION
We don't currently use `time 0.2` downstream in crates.io, so I see no need to merge this for now.

Fixes #3 